### PR TITLE
Add project ready message

### DIFF
--- a/packages/expo-desktop/src/create-app/create-expo-desktop-app.ts
+++ b/packages/expo-desktop/src/create-app/create-expo-desktop-app.ts
@@ -155,6 +155,8 @@ export async function createExpoDesktopApp({
 
   title("Adding Expo support to the Babel config…", { spacing: 1 });
   await writeBabelConfig({ projectPath });
+
+  logProjectReady({ cdPath: name.filesafeName, packageManager });
 }
 
 async function getBundleEntryFileCandidates({ projectPath }: { projectPath: string }) {
@@ -918,4 +920,29 @@ await applyConfigPlugins(info);
     `.trim() + "\n",
     "utf-8",
   );
+}
+
+function logProjectReady({
+  cdPath,
+  packageManager,
+}: {
+  cdPath: string;
+  packageManager: "npm" | "bun" | "pnpm";
+}) {
+  const lines = [
+    "✅ Your project is ready!",
+    "",
+    `To run your project, navigate to the directory and run one of the following ${packageManager} commands.`,
+    "",
+    `- cd ${cdPath}`,
+    `- ${packageManager} start`,
+    `- ${packageManager} run macos`,
+    `- ${packageManager} run windows`,
+    `- ${packageManager} run android`,
+    `- ${packageManager} run ios`,
+    `- ${packageManager} run web`,
+    ""
+  ];
+
+  log.success(lines.join("\n"), { withGuide: false });
 }

--- a/packages/expo-desktop/src/create-app/create-expo-desktop-app.ts
+++ b/packages/expo-desktop/src/create-app/create-expo-desktop-app.ts
@@ -941,7 +941,7 @@ function logProjectReady({
     `- ${packageManager} run android`,
     `- ${packageManager} run ios`,
     `- ${packageManager} run web`,
-    ""
+    "",
   ];
 
   log.success(lines.join("\n"), { withGuide: false });

--- a/packages/expo-desktop/src/create-app/create-expo-desktop-app.ts
+++ b/packages/expo-desktop/src/create-app/create-expo-desktop-app.ts
@@ -927,22 +927,39 @@ function logProjectReady({
   packageManager,
 }: {
   cdPath: string;
-  packageManager: "npm" | "bun" | "pnpm";
+  packageManager: "npm" | "bun" | "pnpm" | "yarn";
 }) {
   const lines = [
     "✅ Your project is ready!",
     "",
-    `To run your project, navigate to the directory and run one of the following ${packageManager} commands.`,
+    "To run your project, first navigate to the directory and start up the packager:",
     "",
     `- cd ${cdPath}`,
-    `- ${packageManager} start`,
-    `- ${packageManager} run macos`,
-    `- ${packageManager} run windows`,
-    `- ${packageManager} run android`,
-    `- ${packageManager} run ios`,
-    `- ${packageManager} run web`,
+    `- ${formatRunCommand(packageManager, "start")}`,
+    "",
+    "… and then run the target platform of your choice:",
+    "",
+    `- ${formatRunCommand(packageManager, "android")}`,
+    `- ${formatRunCommand(packageManager, "ios")}`,
+    `- ${formatRunCommand(packageManager, "web")}`,
+    `- ${formatRunCommand(packageManager, "macos")}`,
+    `- ${formatRunCommand(packageManager, "windows")}`,
     "",
   ];
 
   log.success(lines.join("\n"), { withGuide: false });
+}
+
+export function formatRunCommand(packageManager: "npm" | "bun" | "pnpm" | "yarn", cmd: string) {
+  switch (packageManager) {
+    case "pnpm":
+      return `pnpm run ${cmd}`;
+    case "yarn":
+      return `yarn ${cmd}`;
+    case "bun":
+      return `bun run ${cmd}`;
+    case "npm":
+    default:
+      return `npm run ${cmd}`;
+  }
 }


### PR DESCRIPTION
# Summary
Adds a completion message at the end of create-app to inform users that the CLI has finished and to provide next steps. This also helps align the experience with Expo’s expectations, as it mirrors the output of the expo create app CLI

## Testing
 Run create-app locally and confirm the success message appears after setup with the correct project name and commands.