### PR TITLE
fix: set style for Text on App component

### DIFF
--- a/apps/demo/App.tsx
+++ b/apps/demo/App.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Text, View } from "react-native";
 export default function App() {
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
+      <Text style={styles.text}>Open up App.tsx to start working on your app!</Text>
       <StatusBar style="auto" />
     </View>
   );
@@ -16,5 +16,8 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     alignItems: "center",
     justifyContent: "center",
+  },
+  text: {
+    color: "#000",
   },
 });

--- a/packages/expo-desktop/src/create-app/create-expo-desktop-app.ts
+++ b/packages/expo-desktop/src/create-app/create-expo-desktop-app.ts
@@ -156,6 +156,9 @@ export async function createExpoDesktopApp({
   title("Adding Expo support to the Babel config…", { spacing: 1 });
   await writeBabelConfig({ projectPath });
 
+  title("Improving App.tsx…", { spacing: 1 });
+  await improveAppTsx({ projectPath });
+
   logProjectReady({ cdPath: name.filesafeName, packageManager });
 }
 
@@ -843,6 +846,58 @@ module.exports = function (api) {
   }
 
   console.log(`\n${green("◆")}  Wrote babel.config.js.\n`);
+}
+
+/**
+ * Improve the App.tsx so that it's not white-on-white on macOS in dark mode.
+ * Here, we simply ensure that it's black-on-white in both light and dark modes.
+ *
+ * @see https://github.com/shirakaba/expo-desktop/pull/14#issuecomment-4614018796
+ * @see https://github.com/expo/expo/blob/sdk-54/templates/expo-template-blank-typescript/App.tsx
+ */
+async function improveAppTsx({ projectPath }: { projectPath: string }) {
+  const metroConfigPath = path.resolve(projectPath, "App.tsx");
+
+  console.log(`${cyan("◆")}  Overwriting App.tsx…\n`);
+
+  try {
+    await fs.writeFile(
+      metroConfigPath,
+      `
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Open up App.tsx to start working on your app!</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: '#000',
+  },
+});
+    `.trim() + "\n",
+      "utf-8",
+    );
+  } catch (error) {
+    log.error(
+      `Error improving ${yellow("App.tsx")} file${error instanceof Error ? `: ${error.message}` : "."}`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`\n${green("◆")}  Overwrote App.tsx.\n`);
 }
 
 /**


### PR DESCRIPTION
# Summary

Surely the most useful commit for this project ^^

As kindly asked during App.js, I took a bit of time to test this promising package! I ran `bunx macos` and got a white screen. The PR updates the stylesheet so people trying the package don't get the wrong impression that it is not working.

## Result

Before / After:
<img width="500" alt="Screenshot 2026-06-03 at 13 45 22" src="https://github.com/user-attachments/assets/2e7c75f5-dbf0-446c-8de4-993385a4972f" />
<img width="500" alt="Screenshot 2026-06-03 at 13 40 45" src="https://github.com/user-attachments/assets/2d5882e8-8a76-41a4-b7f8-b9d57a2736bc" />
